### PR TITLE
feat(avatar): add missing presence icon bg

### DIFF
--- a/components/avatar.json
+++ b/components/avatar.json
@@ -10,7 +10,8 @@
       "presenting": "@theme-presence-doNotDisturb",
       "quiet-hours": "@theme-presence-away",
       "away": "@theme-presence-away",
-      "ooo": "@theme-presence-away"
+      "ooo": "@theme-presence-away",
+      "background": "@theme-background-solid-primary-normal"
     },
     "color-avatar": {
       "text": "@theme-text-button-normal",


### PR DESCRIPTION
Add missing presence icon bg token used for the circle bg behind the presence icon.
![image](https://user-images.githubusercontent.com/14194394/129206541-fb2e4ca3-b400-437e-b375-09aa3c8eff7d.png)

