### PR TITLE
match name to hex value sample

### DIFF
--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -103,9 +103,9 @@
         }
       },
       "secondary": {
-        "normal": "@color-white-alpha-11",
-        "hover": "@color-white-alpha-20",
-        "active": "@color-white-alpha-30"
+        "normal": "@color-black-alpha-11",
+        "hover": "@color-black-alpha-20",
+        "active": "@color-black-alpha-30"
       },
       "accent": {
         "normal": "@theme-color-60"


### PR DESCRIPTION
@paulwitty I reviewed these values on the theme tokens figma, and found that the hex values of the color shown in the sample for the light theme did not match the color name provided. they are listed as white-alpha values but the actual color is black-alpha values. 