### PR TITLE
update secondaryActive background color for light theme to have correct value from figma

### DIFF
--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -105,7 +105,7 @@
       "secondary": {
         "normal": "@color-white-alpha-11",
         "hover": "@color-white-alpha-20",
-        "active": "@color-white-alpha-30"
+        "active": "@color-black-alpha-30"
       },
       "accent": {
         "normal": "@theme-color-60"


### PR DESCRIPTION
The `search.json` is referencing the `@theme-background-secondary-active`; however, this theme token in `light-common` is referencing the wrong core token, and should be `@color-black-alpha-30` according to the figma. I suspect that the `normal`/`hover` colors are also incorrect, but only wanted to change what I confirmed was in the figma. 