### PR TITLE
feat: add-gradient-component-for-desktop

### DIFF
--- a/platformcomponents/desktop/gradient.json
+++ b/platformcomponents/desktop/gradient.json
@@ -1,0 +1,26 @@
+{
+  "theme-gradient": {
+    "comment": "Used for graident backgrounds on Desktop (parsing logic requires at least 1 normal UI state)",
+    "figma": "https://www.figma.com/file/6Wrt4B7fn41nqSTgFpgwpc/UI-Color-Themes?node-id=8946%3A41934",
+    "primary-0": {
+      "#normal": {
+        "background": "@theme-background-gradient-primary-0"
+      }
+    },
+    "primary-1": {
+      "#normal": {
+        "background": "@theme-background-gradient-primary-1"
+      }
+    },
+    "secondary-0": {
+      "#normal": {
+        "background": "@theme-background-gradient-secondary-0"
+      }
+    },
+    "secondary-1": {
+      "#normal": {
+        "background": "@theme-background-gradient-secondary-1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description
For the new gradient themes desktop is currently unable to use the `theme-background-gradient-xx` tokens due to our parsing logic expecting each token to have at least 1 UI state (`normal`). Today, the tokens being generated from the `gradiation.json` file have no UI state, and get omitted from the generated theme files if we run the script with `--omitThemeTokens`. Looking back through the history of the `Component Tokens dev discussion` space, this particular issue has already come up and the proposed solution at the time was to add additional component files for desktop where needed.

# Links
[Figma](https://www.figma.com/file/6Wrt4B7fn41nqSTgFpgwpc/UI-Color-Themes?node-id=9364%3A65784)

Discussion in the `Component Tokens dev discussion` space:
![image](https://user-images.githubusercontent.com/22524010/131528056-512575d7-73a1-44af-870c-c86f9c0a80d5.png)

![image](https://user-images.githubusercontent.com/22524010/131528142-4f0b87b0-7873-4afa-9895-32cef65bcec7.png)

