### PR TITLE
fix/button-style/add-button-overlay-style-and-fix-ghost-style

### DIFF
--- a/components/button.json
+++ b/components/button.json
@@ -46,15 +46,15 @@
     "ghost": {
       "#normal": {
         "background": "@theme-button-secondary-normal",
-        "text": "@theme-text-primary-normal",
+        "text": "@theme-globaltint-normal",
         "border": "none"
       },
       "#hovered": {
         "background": "@theme-button-secondary-hover",
-        "text": "@theme-text-primary-normal"
+        "text": "@theme-globaltint-normal"
       },
       "#pressed": {
-        "background": "@theme-button-secondary-pressed",
+        "background": "@theme-globaltint-selected",
         "text": "@theme-text-primary-normal"
       },
       "#disabled": {
@@ -287,6 +287,28 @@
       },
       "#disabled": {
         "background": "@theme-button-inverted-normal",
+        "text": "@theme-text-primary-disabled",
+        "border": "@theme-outline-disabled-normal"
+      }
+    },
+    "overlay": {
+      "#normal": {
+        "background": "@theme-button-inverted-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-secondary-normal"
+      },
+      "#hovered": {
+        "background": "@theme-button-inverted-hovered",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-secondary-normal"
+      },
+      "#pressed": {
+        "background": "@theme-button-inverted-pressed",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-secondary-normal"
+      },
+      "#disabled": {
+        "background": "@theme-button-secondary-normal",
         "text": "@theme-text-primary-disabled",
         "border": "@theme-outline-disabled-normal"
       }

--- a/components/button.json
+++ b/components/button.json
@@ -298,7 +298,7 @@
         "border": "@theme-outline-secondary-normal"
       },
       "#hovered": {
-        "background": "@theme-button-inverted-hovered",
+        "background": "@theme-button-inverted-hover",
         "text": "@theme-text-primary-normal",
         "border": "@theme-outline-secondary-normal"
       },

--- a/components/button.json
+++ b/components/button.json
@@ -43,25 +43,6 @@
         "border": "@theme-outline-disabled-normal"
       }
     },
-    "ghost": {
-      "#normal": {
-        "background": "@theme-button-secondary-normal",
-        "text": "@theme-globaltint-normal",
-        "border": "none"
-      },
-      "#hovered": {
-        "background": "@theme-button-secondary-hover",
-        "text": "@theme-globaltint-normal"
-      },
-      "#pressed": {
-        "background": "@theme-globaltint-selected",
-        "text": "@theme-text-primary-normal"
-      },
-      "#disabled": {
-        "background": "@theme-button-primary-disabled",
-        "text": "@theme-text-primary-disabled"
-      }
-    },
     "cancel-ghost": {
       "#normal": {
         "background": "@theme-button-secondary-normal",
@@ -287,28 +268,6 @@
       },
       "#disabled": {
         "background": "@theme-button-inverted-normal",
-        "text": "@theme-text-primary-disabled",
-        "border": "@theme-outline-disabled-normal"
-      }
-    },
-    "overlay": {
-      "#normal": {
-        "background": "@theme-button-inverted-normal",
-        "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-secondary-normal"
-      },
-      "#hovered": {
-        "background": "@theme-button-inverted-hover",
-        "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-secondary-normal"
-      },
-      "#pressed": {
-        "background": "@theme-button-inverted-pressed",
-        "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-secondary-normal"
-      },
-      "#disabled": {
-        "background": "@theme-button-secondary-normal",
         "text": "@theme-text-primary-disabled",
         "border": "@theme-outline-disabled-normal"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/design-tokens",
-  "version": "0.0.18",
+  "version": "0.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/platformcomponents/android/button.json
+++ b/platformcomponents/android/button.json
@@ -1,0 +1,21 @@
+{
+  "button": {
+    "comment": "Android specific button styles",
+    "figma": "",
+    "ghost": {
+      "#normal": {
+        "background": "@theme-button-secondary-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "none"
+      },
+      "#hovered": {
+        "background": "@theme-button-secondary-hover",
+        "text": "@theme-text-primary-normal"
+      },
+      "#pressed": {
+        "background": "@theme-button-secondary-pressed",
+        "text": "@theme-text-primary-normal"
+      }
+    }
+  }
+}

--- a/platformcomponents/desktop/button.json
+++ b/platformcomponents/desktop/button.json
@@ -1,0 +1,21 @@
+{
+  "button": {
+    "comment": "Desktop specific button styles",
+    "figma": "",
+    "ghost": {
+      "#normal": {
+        "background": "@theme-button-secondary-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "none"
+      },
+      "#hovered": {
+        "background": "@theme-button-secondary-hover",
+        "text": "@theme-text-primary-normal"
+      },
+      "#pressed": {
+        "background": "@theme-button-secondary-pressed",
+        "text": "@theme-text-primary-normal"
+      }
+    }
+  }
+}

--- a/platformcomponents/ios/button.json
+++ b/platformcomponents/ios/button.json
@@ -1,0 +1,25 @@
+{
+  "button": {
+    "comment": "iOS specific button styles",
+    "figma": "https://www.figma.com/file/L67wWWZaXcvVOLEpn77adE/Components---iOS?node-id=2741%3A6797",
+    "ghost": {
+      "#normal": {
+        "background": "@theme-button-secondary-normal",
+        "text": "@theme-globaltint-normal",
+        "border": "none"
+      },
+      "#hovered": {
+        "background": "@theme-button-secondary-hover",
+        "text": "@theme-globaltint-normal"
+      },
+      "#pressed": {
+        "background": "@theme-globaltint-selected",
+        "text": "@theme-text-primary-normal"
+      },
+      "#disabled": {
+        "background": "@theme-button-primary-disabled",
+        "text": "@theme-text-primary-disabled"
+      }
+    }
+  }
+}

--- a/platformcomponents/mobile/button.json
+++ b/platformcomponents/mobile/button.json
@@ -1,0 +1,28 @@
+{
+  "button": {
+    "comment": "Mobile specific button styles",
+    "figma": "https://www.figma.com/file/L67wWWZaXcvVOLEpn77adE/Components---iOS?node-id=2741%3A6797",
+    "overlay": {
+      "#normal": {
+        "background": "@theme-button-inverted-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-secondary-normal"
+      },
+      "#hovered": {
+        "background": "@theme-button-inverted-hover",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-secondary-normal"
+      },
+      "#pressed": {
+        "background": "@theme-button-inverted-pressed",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-secondary-normal"
+      },
+      "#disabled": {
+        "background": "@theme-button-secondary-normal",
+        "text": "@theme-text-primary-disabled",
+        "border": "@theme-outline-disabled-normal"
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

Added the 'overlay' style for momentum buttons and fixed the mapping of 'ghost' styles to match the Figma design

# Links

Figma: https://www.figma.com/file/L67wWWZaXcvVOLEpn77adE/Components---iOS?node-id=2857%3A14660
