### PR TITLE
Fix interactive icon spelling mistake

### DIFF
--- a/platformcomponents/desktop/interactive-icon.json
+++ b/platformcomponents/desktop/interactive-icon.json
@@ -84,7 +84,7 @@
       "#pressed": {
         "background": "@theme-button-secondary-pressed"
       },
-      "disabled":{
+      "#disabled":{
         "background": "@theme-button-secondary-normal"
       }
     }


### PR DESCRIPTION

# Description

spelling mistake in container disabled caused it to generate its own token rather than state of container

# Links

*Links to relevent resources.*
