### PR TITLE
fix(menulistbackground): fix menulist background

### DIFF
--- a/platformcomponents/desktop/menu-list-background.json
+++ b/platformcomponents/desktop/menu-list-background.json
@@ -3,16 +3,22 @@
     "comment": "Applied to Menu List Background",
     "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4518%3A11772",
     "primary": {
-      "background": "@theme-background-solid-primary-normal",
-      "border": "@theme-outline-secondary-normal"
+      "#normal": {
+        "background": "@theme-background-solid-primary-normal",
+        "border": "@theme-outline-secondary-normal"
+      }
     },
     "secondary": {
-      "background": "@theme-background-solid-secondary-normal",
-      "border": "@theme-outline-secondary-normal"
+      "#normal": {
+        "background": "@theme-background-solid-secondary-normal",
+        "border": "@theme-outline-secondary-normal"
+      }
     },
     "tertiary": {
-      "background": "@theme-background-solid-tertiary-normal",
-      "border": "@theme-outline-secondary-normal"
+      "#normal": {
+        "background": "@theme-background-solid-tertiary-normal",
+        "border": "@theme-outline-secondary-normal"
+      }
     }
   }
 }


### PR DESCRIPTION

# Description

Fix the menu list background css by adding the `#normal` level to the json

Without this the css ended up like:
```css
  --menulistbackground-secondary-border-color-0: r;
  --menulistbackground-secondary-border-color-1: g;
  --menulistbackground-secondary-border-color-2: b;
  --menulistbackground-secondary-border-color-3: a;
  --menulistbackground-secondary-border-color-4: (;
  --menulistbackground-secondary-border-color-5: 2;
  --menulistbackground-secondary-border-color-6: 5;
  --menulistbackground-secondary-border-color-7: 5;
  --menulistbackground-secondary-border-color-8: ,;
  --menulistbackground-secondary-border-color-9:  ;
  --menulistbackground-secondary-border-color-10: 2;
  --menulistbackground-secondary-border-color-11: 5;
  --menulistbackground-secondary-border-color-12: 5;
  --menulistbackground-secondary-border-color-13: ,;
  --menulistbackground-secondary-border-color-14:  ;
  --menulistbackground-secondary-border-color-15: 2;
  --menulistbackground-secondary-border-color-16: 5;
  --menulistbackground-secondary-border-color-17: 5;
  --menulistbackground-secondary-border-color-18: ,;
  --menulistbackground-secondary-border-color-19:  ;
  --menulistbackground-secondary-border-color-20: 0;
  --menulistbackground-secondary-border-color-21: .;
  --menulistbackground-secondary-border-color-22: 2;
  --menulistbackground-secondary-border-color-23: );
```
