### PR TITLE
fix(textinput): put active back in

### DIFF
--- a/components/text-input.json
+++ b/components/text-input.json
@@ -23,6 +23,11 @@
       "text": "@theme-text-primary-normal",
       "border": "@theme-outline-focus-normal"
     },
+    "#active": {
+      "background": "@theme-background-primary-active",
+      "text": "@theme-text-primary-normal",
+      "border": "@theme-outline-input-active"
+    },
     "#disabled": {
       "background": "@theme-background-primary-disabled",
       "text": "@theme-text-primary-disabled",


### PR DESCRIPTION

# Description

Add back in `active` for the text input that was still in use by the web
