### PR TITLE
update presence icon colours

### DIFF
--- a/theme-data/dark/dark-common.json
+++ b/theme-data/dark/dark-common.json
@@ -305,7 +305,7 @@
       }
     },
     "presence": {
-      "busy": "@color-yellow-50",
+      "busy": "@color-orange-50",
       "doNotDisturb": "@color-red-50",
       "active": "@color-green-50",
       "away": "@color-gray-50"

--- a/theme-data/dark/dark-common.json
+++ b/theme-data/dark/dark-common.json
@@ -305,10 +305,10 @@
       }
     },
     "presence": {
-      "busy": "@color-yellow-40",
-      "doNotDisturb": "@color-red-40",
-      "active": "@color-green-40",
-      "away": "@color-gray-40"
+      "busy": "@color-yellow-50",
+      "doNotDisturb": "@color-red-50",
+      "active": "@color-green-50",
+      "away": "@color-gray-50"
     },
     "whiteboard": {
       "stickyNote": {

--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -308,7 +308,7 @@
       }
     },
     "presence": {
-      "busy": "@color-yellow-60",
+      "busy": "@color-orange-60",
       "doNotDisturb": "@color-red-60",
       "active": "@color-green-60",
       "away": "@color-gray-60"

--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -308,10 +308,10 @@
       }
     },
     "presence": {
-      "busy": "@color-yellow-70",
-      "doNotDisturb": "@color-red-70",
-      "active": "@color-green-70",
-      "away": "@color-gray-70"
+      "busy": "@color-yellow-60",
+      "doNotDisturb": "@color-red-60",
+      "active": "@color-green-60",
+      "away": "@color-gray-60"
     },
     "whiteboard": {
       "stickyNote": {


### PR DESCRIPTION

# Description

Update the presence icon colours in light and dark mode. Design changed after user feedback

# Links

<img width="1557" alt="Screenshot 2021-09-30 at 17 54 02" src="https://user-images.githubusercontent.com/87858909/135498367-97ab0cf1-0004-403c-bac4-d6eb5dafb209.png">

https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=0%3A1