### PR TITLE
fix: interactive icons component tokens fix

### DIFF
--- a/platformcomponents/desktop/interactive-icon.json
+++ b/platformcomponents/desktop/interactive-icon.json
@@ -2,78 +2,6 @@
   "interactiveicon": {
     "comment": "Applied to icons that are clickable",
     "figma": "https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=6192%3A28111",
-    "favorite": {
-      "#normal": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-warning-normal"
-      },
-      "#hovered": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-warning-hover"
-      },
-      "#pressed": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-warning-active"
-      },
-      "#disabled": {        
-        "icon-inactive": "@theme-text-primary-disabled",
-        "icon-active": "@theme-text-primary-disabled"
-      }
-    },    
-    "settings": {
-      "#normal": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-primary-normal"
-      },
-      "#hovered": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-primary-normal"
-      },
-      "#pressed": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-primary-normal"
-      },
-      "#disabled": {        
-        "icon-inactive": "@theme-text-primary-disabled",
-        "icon-active": "@theme-text-primary-disabled"
-      }      
-    },
-    "attachment": {
-      "#normal": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-accent-normal"
-      },
-      "#hovered": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-accent-hover"
-      },
-      "#pressed": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-accent-active"
-      },
-      "#disabled": {        
-        "icon-inactive": "@theme-text-primary-disabled",
-        "icon-active": "@theme-text-primary-disabled"
-      }
-    },    
-    "flag":{
-      "#normal": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-primary-normal"
-      },
-      "#hovered": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-primary-normal"
-      },
-      "#pressed": {        
-        "icon-inactive": "@theme-text-primary-normal",
-        "icon-active": "@theme-text-primary-normal"
-      },
-      "#disabled": {        
-        "icon-inactive": "@theme-text-primary-disabled",
-        "icon-active": "@theme-text-primary-normal"
-      }
-    },
     "container": {
       "#normal": {
         "background": "@theme-button-secondary-normal"        
@@ -86,6 +14,97 @@
       },
       "#disabled":{
         "background": "@theme-button-secondary-normal"
+      }
+    },
+    "primary": {
+      "filled":{
+        "#normal": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "icon-active": "@theme-text-primary-normal"
+        },
+        "#hovered": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "icon-active": "@theme-text-secondary-normal"
+        },
+        "#pressed": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "icon-active": "@theme-text-secondary-normal"
+        },
+        "#disabled": {        
+          "icon-inactive": "@theme-text-primary-disabled",
+          "icon-active": "@theme-text-primary-disabled"
+        }
+      },
+      "outline":{
+        "#normal": {        
+          "icon-inactive": "@theme-text-secondary-normal",
+          "icon-active": "@theme-text-accent-normal"
+        },
+        "#hovered": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "icon-active": "@theme-text-accent-hover"
+        },
+        "#pressed": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "icon-active": "@theme-text-accent-active"
+        },
+        "#disabled": {        
+          "icon-inactive": "@theme-text-primary-disabled",
+          "icon-active": "@theme-text-primary-disabled"
+        }
+      } 
+    },
+    "secondary":{
+      "filled":{
+        "#normal": {        
+          "icon-inactive": "@theme-text-secondary-normal",
+          "icon-active": "@theme-text-primary-normal"
+        },
+        "#hovered": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "icon-active": "@theme-text-secondary-normal"
+        },
+        "#pressed": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "icon-active": "@theme-text-secondary-normal"
+        },
+        "#disabled": {        
+          "icon-inactive": "@theme-text-primary-disabled",
+          "icon-active": "@theme-text-primary-disabled"
+        }
+      }
+    },
+    "tertiary": {
+      "filled":{
+        "#normal": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "favorite-icon-active": "@theme-text-warning-normal"
+        },
+        "#hovered": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "favorite-icon-active": "@theme-text-warning-hover"
+        },
+        "#pressed": {        
+          "icon-inactive": "@theme-text-primary-normal",
+          "favorite-icon-active": "@theme-text-warning-active"
+        },
+        "#disabled": {        
+          "icon-inactive": "@theme-text-primary-disabled",
+          "icon-active": "@theme-text-primary-disabled"
+        }
+      }
+    },   
+    "quaternary":{
+      "filled":{
+        "#normal": {        
+          "icon-active": "@theme-text-primary-normal"
+        },
+        "#hovered": {
+          "icon-active": "@theme-text-secondary-normal"
+        },
+        "#pressed": {        
+          "icon-active": "@theme-text-primary-normal"
+        }
       }
     }
   }  


### PR DESCRIPTION
# Description

As discussed with the design team and James Nestor, the interactive-icon component tokens needed these fixes:
1. Each level (primary, secondary, tertiary…) have open icons. So any icon can appear. I changed the name of the tokens for the icon from 'settings/favorite/flag…' to 'primary-filled/primary-outline/secondary-filled/tertiary-filled/etc'?
2. Some colors were wrong. For example, some theme tokens were TextSecondary-normal. Previously, all of them where TextPrimary-normal. 
3. On the tertiary level (the favorite icon), the color the icon gets on active is open to change. With the favorite icon, it should turn yellow, but with another icon, the color could be different. Given we know the color of the active state of the favorite icon only, I added '**favorite**-icon-active' to the token name.

# Links

https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4341%3A6826
