### PR TITLE
feat(controls): update theme token colors

### DIFF
--- a/theme-data/dark/dark-common.json
+++ b/theme-data/dark/dark-common.json
@@ -290,13 +290,13 @@
         "hover": "@theme-color-50",
         "pressed": "@theme-color-60",
         "active": "@theme-color-60",
-        "disabled": "@theme-color-90"
+        "disabled": "@theme-color-80"
       },
       "inactive": {
-        "normal": "@color-white-alpha-50",
-        "hover": "@color-white-alpha-11",
-        "pressed": "@color-white-alpha-20",
-        "disabled": "@color-white-alpha-05"
+        "normal": "@color-white-alpha-20",
+        "hover": "@color-white-alpha-30",
+        "pressed": "@color-white-alpha-40",
+        "disabled": "@color-white-alpha-11"
       }
     },
     "presence": {

--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -290,7 +290,7 @@
     "control": {
       "active": {
         "normal": "@theme-color-60",
-        "hover": "@theme-color-50",
+        "hover": "@theme-color-70",
         "pressed": "@theme-color-80",
         "active": "@theme-color-80",
         "disabled": "@theme-color-20"

--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -290,16 +290,16 @@
     "control": {
       "active": {
         "normal": "@theme-color-60",
-        "hover": "@theme-color-70",
+        "hover": "@theme-color-50",
         "pressed": "@theme-color-80",
         "active": "@theme-color-80",
-        "disabled": "@theme-color-05"
+        "disabled": "@theme-color-20"
       },
       "inactive": {
-        "normal": "@color-black-alpha-50",
-        "hover": "@color-black-alpha-11",
-        "pressed": "@color-black-alpha-20",
-        "disabled": "@color-black-alpha-04"
+        "normal": "@color-black-alpha-20",
+        "hover": "@color-black-alpha-30",
+        "pressed": "@color-black-alpha-40",
+        "disabled": "@color-black-alpha-11"
       }
     },
     "presence": {


### PR DESCRIPTION
# Description

I've updated the common controls theme tokens for light and dark based on the figma here: https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861%3A6639 referencing https://www.figma.com/file/n9T5usku57ecvPArT9SpWO/Tokens---Core-Color?node-id=442%3A1 to check the colors.
