### PR TITLE
fix(theme-data): Reverse secondary, tertiary for backgound-solid due to design change

### DIFF
--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -100,10 +100,10 @@
           "normal": "@color-white-alpha-100"
         },
         "secondary": {
-          "normal": "@color-gray-05"
+          "normal": "@color-gray-10"
         },
         "tertiary": {
-          "normal": "@color-gray-10"
+          "normal": "@color-gray-05"
         },
         "quaternary": {
           "normal": "@color-white-alpha-100"


### PR DESCRIPTION
Changes for the following,
UX made changes for the light background, we need to switch the token values for secondary & tertiary


![10_12_53](https://user-images.githubusercontent.com/2640513/137228065-ee119413-a869-4e90-a4b4-2bddb9c2bf54.jpg)
