### PR TITLE
Add archived team marker and update global header border colours

### DIFF
--- a/components/team-marker.json
+++ b/components/team-marker.json
@@ -14,7 +14,8 @@
       "slate": "@theme-text-team-slate-normal",
       "violet": "@theme-text-team-violet-normal",
       "purple": "@theme-text-team-purple-normal",
-      "pink": "@theme-text-team-pink-normal"
+      "pink": "@theme-text-team-pink-normal",
+      "archived": "@theme-outline-secondary-normal"
     }
     
   }

--- a/platformcomponents/desktop/globalheader.json
+++ b/platformcomponents/desktop/globalheader.json
@@ -6,27 +6,32 @@
       "#normal": {
         "background": "@theme-background-secondary-normal",
         "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-input-normal"
+        "border": "@theme-background-primary-ghost",
+        "borderModifier": "@theme-background-primary-ghost"
       },
       "#hovered": {
         "background": "@theme-background-secondary-hover",
         "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-input-normal"
+        "border": "@theme-background-primary-ghost",
+        "borderModifier": "@theme-background-primary-ghost"
       },
       "#active": {
         "background": "@theme-background-secondary-active",
         "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-input-active"
+        "border": "@theme-outline-input-active",
+        "borderModifier": "@theme-outline-input-active"
       },
       "#focused": {
         "background": "@theme-background-secondary-normal",
         "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-focus-normal"
+        "border": "@theme-outline-focus-normal",
+        "borderModifier": "@theme-outline-input-active"
       },
       "#disabled": {
         "background": "@theme-background-secondary-normal",
         "text": "@theme-text-primary-disabled",
-        "border": "@theme-background-primary-ghost"
+        "border": "@theme-background-primary-ghost",
+        "borderModifier": "@theme-background-primary-ghost"
       }
     },
     "textfieldPlaceholderText": {


### PR DESCRIPTION
# Description

Update Global header border tokens
Add archive team marker to team markers

# Links

https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=2338%3A5984
<img width="60" alt="Screenshot 2021-10-14 at 17 28 33" src="https://user-images.githubusercontent.com/87858909/137358849-ff3ad6a9-8590-4ec6-8c0f-aa1658ebfebf.png">
<img width="227" alt="Screenshot 2021-10-14 at 17 28 49" src="https://user-images.githubusercontent.com/87858909/137358854-919b620d-3fd6-4f62-ba34-5bacaca7f696.png">


