### PR TITLE
Fix teaching-text-accent for legacy light themes

### DIFF
--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -408,8 +408,8 @@
       },
       "text": {
         "accent": {
-          "normal": "@theme-color-70",
-          "hover": "@theme-color-90",
+          "normal": "@theme-color-40",
+          "hover": "@theme-color-20",
           "disabled": "@color-white-alpha-40"
         },
         "primary": {


### PR DESCRIPTION
# Description

Fixed teaching-text-accent token for legacy light themes, so that it uses the same value as documented in [Figma](https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861%3A6639) file.

# Links

Figma: https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861%3A6639
