### PR TITLE
Create `overlay` button type under button component

### DIFF
--- a/components/button.json
+++ b/components/button.json
@@ -273,6 +273,24 @@
         "text": "@theme-text-primary-disabled",
         "border": "@theme-outline-disabled-normal"
       }
+    },
+    "overlay": {
+      "figma": "https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=9878%3A35559",
+      "#normal": {
+        "background": "@theme-button-inverted-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-button-normal"
+      },
+      "#hovered": {
+        "background": "@theme-button-inverted-hover",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-button-normal"
+      },
+      "#pressed": {
+        "background": "@theme-button-inverted-pressed",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-button-normal"
+      }
     }
   }
 }


### PR DESCRIPTION
# Guide
```
feat: Create overlay button type
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

*This PR creates a new button type called **overlay** under the button component*

# Links

*https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=9878%3A35559*
