### PR TITLE
fix(theme-data): Correct some background mappings,

### DIFF
--- a/theme-data/dark/dark-common.json
+++ b/theme-data/dark/dark-common.json
@@ -91,13 +91,13 @@
     "background": {
       "primary": {
         "ghost": "@color-white-alpha-00",
-        "hover": "@color-white-alpha-05",
+        "hover": "@color-white-alpha-07",
         "active": "@color-white-alpha-11",
         "disabled": "@color-white-alpha-11"
       },
       "solid": {
         "primary": {
-          "normal": "@color-gray-100"
+          "normal": "@color-black-alpha-100"
         },
         "secondary": {
           "normal": "@color-gray-95"
@@ -112,7 +112,8 @@
       "secondary": {
         "normal": "@color-white-alpha-11",
         "hover": "@color-white-alpha-20",
-        "active": "@color-white-alpha-30"
+        "active": "@color-white-alpha-30",
+        "disabled": "@color-white-alpha-00"
       },
       "accent": {
         "normal": "@theme-color-60"


### PR DESCRIPTION

Fix mismatching between the theme token and them data: https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=0%3A1

<img width="1391" alt="Screen Shot 2021-11-04 at 10 17 06 PM" src="https://user-images.githubusercontent.com/2640513/140333380-65582002-4fad-420d-abc9-2c1ca67761ea.png">
