### PR TITLE
Updated the Error-Text color for text inputs

### DIFF
--- a/components/text-input.json
+++ b/components/text-input.json
@@ -36,22 +36,22 @@
     "error": {
       "#normal": {
         "background": "@theme-background-alert-error-normal",
-        "text": "@theme-text-primary-normal",
+        "text": "@theme-text-error-normal",
         "border": "@theme-outline-cancel-normal"
       },
       "#pressed": {
         "background": "@theme-background-primary-active",
-        "text": "@theme-text-primary-normal",
+        "text": "@theme-text-error-normal",
         "border": "@theme-outline-cancel-normal"
       },
       "#hovered": {
         "background": "@theme-background-primary-hover",
-        "text": "@theme-text-primary-normal",
+        "text": "@theme-text-error-normal",
         "border": "@theme-outline-cancel-normal"
       },
       "#focused": {
         "background": "@theme-background-primary-hover",
-        "text": "@theme-text-primary-normal",
+        "text": "@theme-text-error-normal",
         "border": "@theme-outline-cancel-normal"
       }
     }


### PR DESCRIPTION
Error label texts were using the normal text colors. They have been updated to match the current specs

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*

# Links

*Links to relevent resources.*
