### PR TITLE
Fix missing token in platformcomponents/desktop/text-input

### DIFF
--- a/platformcomponents/desktop/text-input.json
+++ b/platformcomponents/desktop/text-input.json
@@ -1,59 +1,8 @@
 {
   "textinput": {
-    "comment": "Used for all text inputs and their states",
-    "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4429%3A871",
-    "placeholder-text": "@theme-text-secondary-normal",
-    "#normal": {
-      "background": "@theme-background-solid-primary-normal",
-      "text": "@theme-text-primary-normal",
-      "border": "@theme-outline-input-normal"
-    },
+    "comment": "Override the pressed state on desktop as it's not needed",
     "#pressed": {
-      "background": "@theme-background-secondary-active",
-      "text": "@theme-text-primary-normal",
-      "border": "@theme-outline-input-normal"
-    },
-    "#hovered": {
-      "background": "@theme-background-primary-hover",
-      "text": "@theme-text-primary-normal",
-      "border": "@theme-outline-input-normal"
-    },
-    "#focused": {
-      "background": "@theme-background-solid-primary-normal",
-      "text": "@theme-text-primary-normal",
-      "border": "@theme-outline-focus-normal"
-    },
-    "#active": {
-      "background": "@theme-background-primary-active",
-      "text": "@theme-text-primary-normal",
-      "border": "@theme-outline-input-active"
-    },
-    "#disabled": {
-      "background": "@theme-background-primary-disabled",
-      "text": "@theme-text-primary-disabled",
-      "border": "@theme-background-primary-ghost"
-    },
-    "error": {
-      "#normal": {
-        "background": "@theme-background-alert-error-normal",
-        "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-cancel-normal"
-      },
-      "#pressed": {
-        "background": "@theme-background-primary-active",
-        "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-cancel-normal"
-      },
-      "#hovered": {
-        "background": "@theme-background-primary-hover",
-        "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-cancel-normal"
-      },
-      "#focused": {
-        "background": "@theme-background-primary-hover",
-        "text": "@theme-text-primary-normal",
-        "border": "@theme-outline-cancel-normal"
-      }
+      "text": "@theme-text-primary-normal"
     }
   }
 }


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

When #156 was merged, it broke the `npm run build:windows` script as the new platform-specific file for `text-input` tokens included a token which was removed in a marge conflict. This PR fixes that issue by removing the unneeded tokens from `platformcomponents/desktop/text-input.json`, as only one field in that needs to overridden.

# Links

*Links to relevent resources.*
