### PR TITLE
add closed caption color token

### DIFF
--- a/components/closed-caption.json
+++ b/components/closed-caption.json
@@ -1,0 +1,38 @@
+{
+  "closedcaption": {
+    "comment": "",
+    "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=40865%3A50204",
+    "background-light": "@theme-common-control-closedcaption-background-light",
+    "background-dark": "@theme-common-control-closedcaption-background-dark",
+    "speaker-light": "@theme-common-control-closedcaption-speaker-light",
+    "speaker-dark": "@theme-common-control-closedcaption-speaker-dark",
+    "text-light": "@theme-common-control-closedcaption-text-light",
+    "text-dark": "@theme-common-control-closedcaption-text-dark",
+    "button-light": {
+      "#normal": {
+        "background": "@theme-common-control-closedcaption-button-light-normal",
+        "text": "@theme-common-control-closedcaption-text-light",
+        "border": "@theme-common-control-closedcaption-button-light-border-normal"
+      },
+      "#hovered": {
+        "background": "@theme-common-control-closedcaption-button-light-hover"
+      },
+      "#pressed": {
+        "background": "@theme-common-control-closedcaption-button-light-pressed"
+      }
+    },
+    "button-dark": {
+      "#normal": {
+        "background": "@theme-common-control-closedcaption-button-dark-normal",
+        "text": "@theme-common-control-closedcaption-text-dark",
+        "border": "@theme-common-control-closedcaption-button-dark-border-normal"
+      },
+      "#hovered": {
+        "background": "@theme-common-control-closedcaption-button-dark-hover"
+      },
+      "#pressed": {
+        "background": "@theme-common-control-closedcaption-button-dark-pressed"
+      }
+    }
+  }
+}

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -46,6 +46,32 @@
           "active": "@color-orange-60",
           "inactive": "@color-gray-60",
           "selected": "@color-green-40"
+        },
+        "closedcaption": {
+          "background-light": "@color-white-alpha-100",
+          "background-dark": "@color-gray-95",
+          "speaker-light": "@color-gray-60",
+          "speaker-dark": "@color-gray-50",
+          "text-light": "@color-black-alpha-95",
+          "text-dark": "@color-white-alpha-95",
+          "button-light": {
+            "normal": "@color-black-alpha-00",
+            "hover": "@color-black-alpha-07",
+            "pressed": "@color-black-alpha-20",
+            "disabled": "@color-white-alpha-00",
+            "border": {
+              "normal": "@color-gray-20"
+            }
+          },
+          "button-dark": {
+            "normal": "@color-white-alpha-00",
+            "hover": "@color-white-alpha-07",
+            "pressed": "@color-white-alpha-20",
+            "disabled": "@color-white-alpha-00",
+            "border": {
+              "normal": "@color-gray-80"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
# Guide
UX has add the close caption to the library.
https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=40865%3A50204
Add the color token for the control.
Note:
  These. color are not change when theme change. 
  In each, user can changed the color of the closed caption box

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*

# Links

*Links to relevent resources.*
