### PR TITLE
Add join meeting animated button color token

### DIFF
--- a/components/button.json
+++ b/components/button.json
@@ -121,6 +121,11 @@
         "border": "@theme-outline-disabled-normal"
       }
     },
+    "join-animated-gradient": {
+      "#normal": {
+        "background": "@theme-common-button-join-animated-gradient"
+      }
+    },
     "cancel-fill": {
       "#normal": {
         "background": "@theme-button-cancel-normal",

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -28,6 +28,9 @@
           "hover": "@color-white-alpha-07",
           "pressed": "@color-white-alpha-20",
           "disabled": "@color-white-alpha-00"
+        },
+        "join-animated-gradient": {
+          "normal": ["@color-mint-40", "@color-blue-40"]
         }
       },
       "outline": {

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -29,6 +29,9 @@
           "hover": "@color-hc-SystemColorHighlightColor",
           "pressed": "@color-hc-SystemColorHighlightColor",
           "disabled": "@color-hc-SystemColorGrayTextColor"
+        },
+        "join-animated-gradient": {
+          "normal": ["@color-mint-40", "@color-blue-40"]
         }
       },
       "outline": {


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
Add join meeting animated button color token, it's a gradient background containing two colors: 
"@color-blue-40" and "@color-mint-40".

# Links

*Links to relevent resources.*
VD: https://www.figma.com/file/c1P3h0DkX7MuhQbc1bP3Za/Animated-Join-Button-Specs?node-id=0%3A1
