### PR TITLE
add closed caption tokens

### DIFF
--- a/components/closed-caption.json
+++ b/components/closed-caption.json
@@ -1,0 +1,38 @@
+{
+  "closedcaption": {
+    "comment": "",
+    "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=40865%3A50204",
+    "background-light": "@theme-common-background-solid-primary-light",
+    "background-dark": "@theme-common-background-solid-secondary-dark",
+    "speaker-light": "@theme-common-text-secondary-dark",
+    "speaker-dark": "@theme-common-text-secondary-light",
+    "text-light": "@theme-common-text-black",
+    "text-dark": "@theme-common-text-white",
+    "button-light": {
+      "#normal": {
+        "background": "@theme-common-button-secondary-normal",
+        "text": "@theme-common-text-black",
+        "border": "@theme-common-outline-closed-caption-secondary-dark"
+      },
+      "#hovered": {
+        "background": "@theme-common-button-secondary-hover"
+      },
+      "#pressed": {
+        "background": "@theme-common-button-secondary-pressed"
+      }
+    },
+    "button-dark": {
+      "#normal": {
+        "background": "@theme-common-button-secondary-dark-normal",
+        "text": "@theme-common-text-white",
+        "border": "@theme-common-outline-closed-caption-secondary-light"
+      },
+      "#hovered": {
+        "background": "@theme-common-button-secondary-dark-hover"
+      },
+      "#pressed": {
+        "background": "@theme-common-button-secondary-dark-pressed"
+      }
+    }
+  }
+}

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -6,7 +6,9 @@
         "black": "@color-black-alpha-95",
         "disabled": "@color-white-alpha-40",
         "success": "@color-green-40",
-        "error": "@color-red-40"
+        "error": "@color-red-40",
+        "secondary-light": "@color-white-alpha-70",
+        "secondary-dark": "@color-black-alpha-60"
       },
       "overlay": {
         "primary": {
@@ -29,6 +31,12 @@
           "pressed": "@color-white-alpha-20",
           "disabled": "@color-white-alpha-00"
         },
+        "secondary-dark": {
+          "normal": "@color-black-alpha-00",
+          "hover": "@color-black-alpha-07",
+          "pressed": "@color-black-alpha-20",
+          "disabled": "@color-black-alpha-00"
+        },
         "join-animated-gradient": {
           "normal": ["@color-mint-40", "@color-blue-40"]
         }
@@ -42,6 +50,12 @@
         },
         "disabled": {
           "normal": "@color-white-alpha-20"
+        },
+        "closed-caption": {
+          "secondary": {
+            "light": "@color-white-alpha-20",
+            "dark": "@color-black-alpha-20"
+          }
         }
       },
       "control": {
@@ -49,6 +63,12 @@
           "active": "@color-orange-60",
           "inactive": "@color-gray-60",
           "selected": "@color-green-40"
+        }
+      },
+      "background": {
+        "solid": {
+          "secondary-dark": "@color-gray-95",
+          "primary-light": "@color-white-alpha-100"
         }
       }
     }

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -7,7 +7,9 @@
         "black": "@color-hc-SystemColorHighlightTextColor",
         "disabled": "@color-hc-SystemColorGrayTextColor",
         "success": "@color-hc-PlaceholderColor",
-        "error": "@color-hc-PlaceholderColor"
+        "error": "@color-hc-PlaceholderColor",
+        "secondary-light": "@color-hc-SystemColorButtonTextColor",
+        "secondary-dark": "@color-hc-SystemColorHighlightTextColor"
       },
       "overlay": {
         "primary": {
@@ -30,6 +32,12 @@
           "pressed": "@color-hc-SystemColorHighlightColor",
           "disabled": "@color-hc-SystemColorGrayTextColor"
         },
+        "secondary-dark": {
+          "normal": "@color-hc-SystemColorButtonFaceColor",
+          "hover": "@color-hc-SystemColorHighlightColor",
+          "pressed": "@color-hc-SystemColorHighlightColor",
+          "disabled": "@color-hc-SystemColorGrayTextColor"
+        },
         "join-animated-gradient": {
           "normal": ["@color-mint-40", "@color-blue-40"]
         }
@@ -43,6 +51,12 @@
         },
         "disabled": {
           "normal": "@color-hc-PlaceholderColor"
+        },
+        "closed-caption": {
+          "secondary": {
+            "light": "@color-hc-SystemColorButtonTextColor",
+            "dark": "@color-hc-SystemColorButtonTextColor"
+          }
         }
       },
       "control": {
@@ -50,6 +64,12 @@
           "active": "@color-hc-PlaceholderColor",
           "inactive": "@color-hc-PlaceholderColor",
           "selected": "@color-hc-PlaceholderColor"
+        }
+      },
+      "background": {
+        "solid": {
+          "secondary-dark": "@color-hc-SystemColorWindowTextColor",
+          "primary-light": "@color-hc-SystemColorWindowTextColor"
         }
       }
     },


### PR DESCRIPTION
# Guide
UX has add the close caption to the library.
https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=40865%3A50204
Add the color token for the control.
Note:
  These. color are not change when theme change. 
  In each, user can changed the color of the closed caption box
