### PR TITLE
Modify color token for join animated button on win high contrast theme

### DIFF
--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -39,7 +39,7 @@
           "disabled": "@color-hc-SystemColorGrayTextColor"
         },
         "join-animated-gradient": {
-          "normal": ["@color-mint-40", "@color-blue-40"]
+          "normal": ["@color-hc-SystemColorButtonFaceColor", "@color-hc-SystemColorButtonFaceColor"]
         }
       },
       "outline": {


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
A fix for PR (https://github.com/momentum-design/tokens/pull/163) to solve Webex UITest error under win high contrast theme.


# Links

*Links to relevent resources.*
VD: https://www.figma.com/file/c1P3h0DkX7MuhQbc1bP3Za/Animated-Join-Button-Specs?node-id=0%3A1
Relative PR: https://github.com/momentum-design/tokens/pull/163