### PR TITLE
Fix using none token on things that are not borders

### DIFF
--- a/platformcomponents/desktop/globalheader.json
+++ b/platformcomponents/desktop/globalheader.json
@@ -7,14 +7,14 @@
         "background": "@theme-background-secondary-normal",
         "text": "@theme-text-primary-normal",
         "border": "none",
-        "borderModifier": "none",
+        "borderModifier": "@theme-background-primary-ghost",
         "searchIcon": "@theme-text-primary-normal"
       },
       "#hovered": {
         "background": "@theme-background-secondary-hover",
         "text": "@theme-text-primary-normal",
         "border": "none",
-        "borderModifier": "none",
+        "borderModifier": "@theme-background-primary-ghost",
         "searchIcon": "@theme-text-primary-normal"
       },
       "#active": {
@@ -35,7 +35,7 @@
         "background": "@theme-background-secondary-normal",
         "text": "@theme-text-primary-disabled",
         "border": "none",
-        "borderModifier": "none",
+        "borderModifier": "@theme-background-primary-ghost",
         "searchIcon": "@theme-text-primary-disabled"
       }
     },

--- a/platformcomponents/desktop/video-support.json
+++ b/platformcomponents/desktop/video-support.json
@@ -32,7 +32,7 @@
     },
     "videoNameLabels": {
       "videoOff": {
-        "background": "none",
+        "background": "@theme-background-primary-ghost",
         "name": "@theme-text-primary-normal",
         "icon": "@theme-text-primary-normal",
         "role": "@theme-text-secondary-normal"


### PR DESCRIPTION
The "none" only works with auto generation on desktop with the "border" type. Update none on other types to use transparent tokens to fix desktop