### PR TITLE
add share active button

### DIFF
--- a/platformcomponents/desktop/share.json
+++ b/platformcomponents/desktop/share.json
@@ -64,6 +64,28 @@
             "text": "@theme-common-text-disabled",
             "border": "@theme-common-outline-disabled-normal"
           }
+        },
+        "active": {
+          "#normal": {
+            "background": "@theme-common-button-secondary-active-normal",
+            "text": "@theme-common-text-white",
+            "border": "@theme-common-outline-button-normal"
+          },
+          "#hovered": {
+            "background": "@theme-common-button-secondary-active-hover",
+            "text": "@theme-common-text-white",
+            "border": "@theme-common-outline-button-normal"
+          },
+          "#pressed": {
+            "background": "@theme-common-button-secondary-active-pressed",
+            "text": "@theme-common-text-white",
+            "border": "@theme-common-outline-button-normal"
+          },
+          "#disabled": {
+            "background": "@theme-common-button-secondary-disabled",
+            "text": "@theme-common-text-disabled",
+            "border": "@theme-common-outline-disabled-normal"
+          }
         }
       }
     },

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -29,7 +29,12 @@
           "normal": "@color-white-alpha-00",
           "hover": "@color-white-alpha-07",
           "pressed": "@color-white-alpha-20",
-          "disabled": "@color-white-alpha-00"
+          "disabled": "@color-white-alpha-00",
+          "active": {
+            "normal": "@color-black-alpha-20",
+            "hover": "@color-black-alpha-30",
+            "pressed": "@color-black-alpha-40"
+          }
         },
         "secondary-dark": {
           "normal": "@color-black-alpha-00",

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -30,7 +30,12 @@
           "normal": "@color-hc-SystemColorButtonFaceColor",
           "hover": "@color-hc-SystemColorHighlightColor",
           "pressed": "@color-hc-SystemColorHighlightColor",
-          "disabled": "@color-hc-SystemColorGrayTextColor"
+          "disabled": "@color-hc-SystemColorGrayTextColor",
+          "active": {
+            "normal": "@color-hc-SystemColorButtonFaceColor",
+            "hover": "@color-hc-SystemColorHighlightColor",
+            "pressed": "@color-hc-SystemColorHighlightColor"
+          }
         },
         "secondary-dark": {
           "normal": "@color-hc-SystemColorButtonFaceColor",


### PR DESCRIPTION
Add missing share button that had been manually added to momentum tokens

https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=8109%3A34645