### PR TITLE
style/Add checkbox HC tokens

### DIFF
--- a/platformcomponents/win-hc/checkbox.json
+++ b/platformcomponents/win-hc/checkbox.json
@@ -1,0 +1,53 @@
+{
+  "checkbox": {
+    "figma": "https://www.figma.com/file/rNpQFybgpgSfTmhLa441V3/Components---Windows-OS-HighContrast?node-id=4371%3A9978",
+    "checked": {
+      "#normal": {
+        "background": "@theme-common-hc-highlight",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-common-hc-highlight",
+        "icon": "@theme-common-hc-highlightText"
+      },
+      "#hovered": {
+        "background": "@theme-common-hc-buttonFace",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-common-hc-highlight",
+        "icon": "@theme-common-hc-buttonText"
+      },
+      "#pressed": {
+        "background": "@theme-common-hc-buttonFace",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-common-hc-highlight",
+        "icon": "@theme-common-hc-buttonText"
+      },
+      "#disabled": {
+        "background": "@theme-common-hc-grayText",
+        "text": "@theme-text-primary-disabled",
+        "border": "@theme-common-hc-grayText",
+        "icon": "@theme-common-hc-highlightText"
+      }
+    },
+    "unchecked": {
+      "#normal": {
+        "background": "@theme-common-hc-buttonFace",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-common-hc-highlight"
+      },
+      "#hovered": {
+        "background": "@theme-common-hc-buttonFace",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-common-hc-highlight"
+      },
+      "#pressed": {
+        "background": "@theme-common-hc-buttonFace",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-common-hc-highlight"
+      },
+      "#disabled": {
+        "background": "@theme-common-hc-grayText",
+        "text": "@theme-text-primary-disabled",
+        "border": "@theme-common-hc-grayText"
+      }
+    }
+  }
+}

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -2,6 +2,16 @@
   "theme": {
     "color": "@color-hc-PlaceholderColor",
     "common": {
+      "hc": {
+        "windowText": "@color-hc-SystemColorWindowTextColor",
+        "hotlight": "@color-hc-SystemColorHotlightColor",
+        "grayText": "@color-hc-SystemColorGrayTextColor",
+        "highlightText": "@color-hc-SystemColorHighlightTextColor",
+        "highlight": "@color-hc-SystemColorHighlightColor",
+        "buttonText": "@color-hc-SystemColorButtonTextColor",
+        "buttonFace": "@color-hc-SystemColorButtonFaceColor",
+        "window": "@color-hc-SystemColorWindowColor"
+      },
       "text": {
         "white": "@color-hc-SystemColorButtonTextColor",
         "black": "@color-hc-SystemColorHighlightTextColor",


### PR DESCRIPTION
# Description

https://www.figma.com/file/rNpQFybgpgSfTmhLa441V3/Components---Windows-OS-HighContrast?node-id=4371%3A9978

For high contrast mode, there are a total of only 8 kinds of colors. Visual design directly uses those colors such as "@color-hc-SystemColorButtonTextColor" instead of tokens like "@theme-control-active-hover". So I think it is better to define those tokens with their original names, to more intuitively match the design.

# Links

*Links to relevent resources.*
