### PR TITLE
Fix/HC-inputText-backgroud-hover-state/not-contrast-while-hover-on-input-text-on-high-contrast

### DIFF
--- a/platformcomponents/win-hc/text-input.json
+++ b/platformcomponents/win-hc/text-input.json
@@ -1,0 +1,9 @@
+{
+  "textinput": {
+    "comment": "Used for all text inputs and their states",
+    "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4429%3A871",
+    "#hovered": {
+      "background": "@theme-background-solid-primary-normal"
+    }
+  }
+}


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description
While hovering on the input-text the background color should be windowColor


# Links

*Links to relevent resources.*
