### PR TITLE
fix the color token for video support name label

### DIFF
--- a/platformcomponents/desktop/video-support.json
+++ b/platformcomponents/desktop/video-support.json
@@ -44,18 +44,18 @@
         "name": "@theme-common-text-white",
         "icon": "@theme-common-text-white",
         "role": "@theme-text-secondary-normal",
-        "iconMute": "@theme-common-text-error",
-        "iconUnmute": "@theme-common-text-success"
+        "iconMute": "@theme-common-text-error-normal",
+        "iconUnmute": "@theme-common-text-success-normal"
       }
     },
     "slider": {
       "track": {
-          "fill": "@theme-control-active-normal",
-          "empty": "@theme-outline-button-normal"
+        "fill": "@theme-control-active-normal",
+        "empty": "@theme-outline-button-normal"
       },
       "mover": {
-          "border": "@theme-outline-primary-normal",
-          "background": "@theme-background-solid-tertiary-normal"
+        "border": "@theme-outline-primary-normal",
+        "background": "@theme-background-solid-tertiary-normal"
       },
       "border": "@theme-outline-button-normal",
       "background": "@theme-button-inverted-normal"


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description
Fix the usage of @theme-common-text-error and @theme-common-text-success. Cause normal and hover status have been added into these two theme.
Caused by https://github.com/momentum-design/tokens/pull/214

# Links

*Links to relevent resources.*
