### PR TITLE
feat(chips/components): add tokens to chips

### DIFF
--- a/components/chips.json
+++ b/components/chips.json
@@ -3,6 +3,8 @@
     "comment": "Applied to Chips",
     "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=5028%3A270",
     "outline": {
+      "error": "@theme-outline-cancel-normal",
+      "normal": "@theme-outline-primary-normal",
       "multiline": {
         "background": "@theme-background-primary-ghost",
         "text": {
@@ -16,6 +18,12 @@
           "violet": "@theme-text-team-violet-normal"
         }
       }
+    },
+    "background": {
+      "error": "@theme-background-alert-error-normal"
+    },
+    "text": {
+      "error": "@theme-text-error-normal"
     }
   }
 }


### PR DESCRIPTION
# Description
Add a couple tokens to chip tokens so that we will reference only chip tokens and not theme tokens in the component code.

# Links
[PR for chips in momentum-react-v2](https://github.com/momentum-design/momentum-react-v2/pull/260)
[figma](https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=5028%3A270)