### PR TITLE
add touch bar tokens mac

### DIFF
--- a/platformcomponents/desktop/touchbar.json
+++ b/platformcomponents/desktop/touchbar.json
@@ -16,6 +16,7 @@
     },
     "icon": {
       "primary": "@theme-common-touchbar-icon-primary",
+      "secondary": "@theme-common-touchbar-icon-secondary",
       "mute": "@theme-common-touchbar-icon-error"
     }
     

--- a/platformcomponents/desktop/touchbar.json
+++ b/platformcomponents/desktop/touchbar.json
@@ -1,0 +1,23 @@
+{
+  "touchbar": {
+    "comment": "applied to items in the touch bar on mac",
+    "figma": "https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=15991%3A144836",
+    "background": {
+      "messages": "@theme-common-touchbar-background-blue",
+      "contacts": "@theme-common-touchbar-background-mint",
+      "content": "@theme-common-touchbar-background-pink",
+      "call": "@theme-common-touchbar-background-green",
+      "whiteboard": "@theme-common-touchbar-background-purple",
+      "meetings": "@theme-common-touchbar-background-orange",
+      "links": "@theme-common-touchbar-background-violet",
+      "encCall": "@theme-common-touchbar-background-red",
+      "toggleMuteAudio": "@theme-common-touchbar-background-transparent",
+      "toggleMuteVideo": "@theme-common-touchbar-background-transparent"
+    },
+    "icon": {
+      "primary": "@theme-common-touchbar-icon-primary",
+      "mute": "@theme-common-touchbar-icon-error"
+    }
+    
+  }
+}

--- a/platformcomponents/desktop/touchbar.json
+++ b/platformcomponents/desktop/touchbar.json
@@ -10,7 +10,7 @@
       "whiteboard": "@theme-common-touchbar-background-purple",
       "meetings": "@theme-common-touchbar-background-orange",
       "links": "@theme-common-touchbar-background-violet",
-      "encCall": "@theme-common-touchbar-background-red",
+      "endCall": "@theme-common-touchbar-background-red",
       "toggleMuteAudio": "@theme-common-touchbar-background-transparent",
       "toggleMuteVideo": "@theme-common-touchbar-background-transparent"
     },

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -88,6 +88,22 @@
           "primary-light": "@color-white-alpha-100"
         }
       }
+    },
+    "touchbar": {
+      "background": {
+        "blue": "@color-blue-60",
+        "pink": "@color-pink-60",
+        "orange": "@color-orange-60",
+        "mint": "@color-mint-60",
+        "purple": "@color-purple-60",
+        "violet": "@color-violet-60",
+        "red": "@color-red-60",
+        "transparent": "@color-black-alpha-00"
+      },
+      "icon": {
+        "primary": "@color-white-alpha-95",
+        "error": "@color-red-40"
+      }
     }
   }
 }

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -102,6 +102,7 @@
         },
         "icon": {
           "primary": "@color-white-alpha-95",
+          "secondary": "@color-blue-40",
           "error": "@color-red-40"
         }
       }

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -87,22 +87,23 @@
           "secondary-dark": "@color-gray-95",
           "primary-light": "@color-white-alpha-100"
         }
-      }
-    },
-    "touchbar": {
-      "background": {
-        "blue": "@color-blue-60",
-        "pink": "@color-pink-60",
-        "orange": "@color-orange-60",
-        "mint": "@color-mint-60",
-        "purple": "@color-purple-60",
-        "violet": "@color-violet-60",
-        "red": "@color-red-60",
-        "transparent": "@color-black-alpha-00"
       },
-      "icon": {
-        "primary": "@color-white-alpha-95",
-        "error": "@color-red-40"
+      "touchbar": {
+        "background": {
+          "blue": "@color-blue-60",
+          "pink": "@color-pink-60",
+          "orange": "@color-orange-60",
+          "mint": "@color-mint-60",
+          "green": "@color-green-60",
+          "purple": "@color-purple-60",
+          "violet": "@color-violet-60",
+          "red": "@color-red-60",
+          "transparent": "@color-black-alpha-00"
+        },
+        "icon": {
+          "primary": "@color-white-alpha-95",
+          "error": "@color-red-40"
+        }
       }
     }
   }

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -98,6 +98,23 @@
           "secondary-dark": "@color-hc-SystemColorWindowTextColor",
           "primary-light": "@color-hc-SystemColorWindowTextColor"
         }
+      },    
+      "touchbar": {
+        "background": {
+          "blue": "@color-hc-PlaceholderColor",
+          "pink": "@color-hc-PlaceholderColor",
+          "orange": "@color-hc-PlaceholderColor",
+          "green": "@color-hc-PlaceholderColor",
+          "mint": "@color-hc-PlaceholderColor",
+          "purple": "@color-hc-PlaceholderColor",
+          "violet": "@color-hc-PlaceholderColor",
+          "red": "@color-hc-PlaceholderColor",
+          "transparent": "@color-hc-PlaceholderColor"
+        },
+        "icon": {
+          "primary": "@color-hc-PlaceholderColor",
+          "error": "@color-hc-PlaceholderColor"
+        }
       }
     },
     "text": {
@@ -569,7 +586,7 @@
         "primary": {
           "disabled": "@color-hc-SystemColorGrayTextColor"
         }
-      }
+      }      
     }
   }
 }

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -587,7 +587,7 @@
         "primary": {
           "disabled": "@color-hc-SystemColorGrayTextColor"
         }
-      }      
+      }
     }
   }
 }

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -113,6 +113,7 @@
         },
         "icon": {
           "primary": "@color-hc-PlaceholderColor",
+          "secondary": "@color-hc-PlaceholderColor",
           "error": "@color-hc-PlaceholderColor"
         }
       }


### PR DESCRIPTION
Add colour tokens for touch bar on mac

https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=15991%3A144836
https://www.figma.com/file/uTiF8j59yEbhbT3pgLYgxs/Tokens---Theme-Color---Additional?node-id=1302%3A979

<img width="408" alt="Screenshot 2022-06-22 at 13 46 20" src="https://user-images.githubusercontent.com/87858909/175032450-44048f56-84cc-4423-80b5-f5188a68ae1f.png">
