### PR TITLE
feat: fix TextInput placeholder and border colors in High Contrast mode

### DIFF
--- a/platformcomponents/win-hc/text-input.json
+++ b/platformcomponents/win-hc/text-input.json
@@ -1,9 +1,19 @@
 {
   "textinput": {
     "comment": "Used for all text inputs and their states",
-    "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4429%3A871",
+    "figma": "https://www.figma.com/file/rNpQFybgpgSfTmhLa441V3/Components---Windows-OS-HighContrast?node-id=4347%3A919",
+    "#normal": {
+      "placeholder-text": "@theme-text-secondary-normal"
+    },
     "#hovered": {
+      "text": "@theme-text-inverted-normal",
+      "placeholder-text": "@theme-text-inverted-normal",
       "background": "@theme-background-solid-primary-normal"
+    },
+    "#disabled": {
+      "text": "@theme-text-primary-disabled",
+      "placeholder-text": "@theme-text-primary-disabled",
+      "border": "@theme-outline-disabled-normal"
     }
   }
 }


### PR DESCRIPTION
# Description

* Fixed TextInput placeholder and border colors in High Contrast mode

| Before                                                                                                                                | After                                                                                                                                |
|---------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
| ![Before_HCTextInputDisabled](https://user-images.githubusercontent.com/621738/175069427-a64b5aaa-b94a-4ad6-b25a-f884995c254a.png)    | ![After_HCTextInputDisabled](https://user-images.githubusercontent.com/621738/175069450-5b93b61e-dafb-47c9-aa36-b19d6cc4ea06.png)    |
| ![Before_HCTextInputPlaceholder](https://user-images.githubusercontent.com/621738/175069437-332b4457-502b-47a5-8bdc-d63fe10a5fd6.gif) | ![After_HCTextInputPlaceholder](https://user-images.githubusercontent.com/621738/175069459-d30ee574-e2d0-4c2d-8118-14b92c4f9efe.gif) |

# Links

https://www.figma.com/file/rNpQFybgpgSfTmhLa441V3/Components---Windows-OS-HighContrast?node-id=4347%3A919
