### PR TITLE
Fix text secondary inverted token for light mode

### DIFF
--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -13,7 +13,7 @@
       "secondary": {
         "normal": "@color-black-alpha-60",
         "inverted": {
-          "normal": "@color-black-alpha-70"
+          "normal": "@color-white-alpha-70"
         }
       },
       "error": {


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

* text secondary inverted was using the wrong color token for light mode. 

# Links
Figma:
![Screen Shot 2022-07-06 at 9 59 52 AM](https://user-images.githubusercontent.com/43631585/177612935-6a2c1de6-81a1-4830-a4a6-c352760fa18c.png)


*Links to relevent resources.*
