### PR TITLE
SPARK-346727: RadioButton Color Token added to momentum repo

### DIFF
--- a/platformcomponents/desktop/radiobutton.json
+++ b/platformcomponents/desktop/radiobutton.json
@@ -1,0 +1,50 @@
+{
+  "radiobutton": {
+    "comment": "Applied to radiobutton Components.",
+    "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=46518%3A103488",
+    "checked": {
+      "#normal": {
+        "background": "@theme-text-inverted-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-control-active-normal"
+      },
+      "#hovered": {
+        "background": "@theme-text-inverted-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-control-inactive-hover"
+      },
+      "#pressed": {
+        "background": "@theme-text-inverted-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-control-active-pressed"
+      },
+      "#disabled": {
+        "background": "@theme-text-inverted-disabled",
+        "text": "@theme-text-primary-disabled",
+        "border": "@theme-control-active-disabled"
+      }
+    },
+    "unchecked": {
+      "#normal": {
+        "background": "@theme-common-control-inactive-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-input-normal"
+      },
+      "#hovered": {
+        "background": "@theme-common-control-inactive-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-input-normal"
+      },
+      "#pressed": {
+        "background": "@theme-common-control-inactive-normal",
+        "text": "@theme-text-primary-normal",
+        "border": "@theme-outline-input-normal"
+      },
+      "#disabled": {
+        "background": "@theme-control-inactive-hover",
+        "text": "@theme-text-primary-disabled",
+        "border": "none"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Link: https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=46518%3A103707

PR: add radio button color token to momentum repo

picture:
![image](https://user-images.githubusercontent.com/107181428/179751098-3f0d3289-62ad-4462-be30-62de27fab048.png)

