### PR TITLE
fix(win-hc): Use correct colours and add borders for interactive-icons

### DIFF
--- a/platformcomponents/desktop/interactive-icon.json
+++ b/platformcomponents/desktop/interactive-icon.json
@@ -4,16 +4,20 @@
     "figma": "https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=6192%3A28111",
     "container": {
       "#normal": {
-        "background": "@theme-button-secondary-normal"        
+        "background": "@theme-button-secondary-normal",
+        "border": "none"
       },
       "#hovered": {
-        "background": "@theme-button-secondary-hover"        
+        "background": "@theme-button-secondary-hover",
+        "border": "none"
       },
       "#pressed": {
-        "background": "@theme-button-secondary-pressed"
+        "background": "@theme-button-secondary-pressed",
+        "border": "none"
       },
-      "#disabled":{
-        "background": "@theme-button-secondary-normal"
+      "#disabled": {
+        "background": "@theme-button-secondary-normal",
+        "border": "none"
       }
     },
     "primary": {

--- a/platformcomponents/win-hc/interactive-icon.json
+++ b/platformcomponents/win-hc/interactive-icon.json
@@ -2,6 +2,9 @@
   "interactiveicon": {
     "comment": "Applied to icons that are clickable",
     "figma": "https://www.figma.com/file/rNpQFybgpgSfTmhLa441V3/Components---Windows-OS-HighContrast?node-id=18590%3A37844",
+    "container": {
+      "border": "@theme-common-hc-buttonText"
+    },
     "primary": {
       "filled": {
         "#normal": {
@@ -15,6 +18,22 @@
         "#pressed": {
           "icon-inactive": "@theme-common-hc-highlightText",
           "icon-active": "@theme-common-hc-highlightText"
+        }
+      }
+    },
+    "tertiary": {
+      "filled": {
+        "#normal": {
+          "icon-inactive": "@theme-common-hc-buttonText",
+          "favorite-icon-active": "@theme-common-hc-highlight"
+        },
+        "#hovered": {
+          "icon-inactive": "@theme-common-hc-highlightText",
+          "favorite-icon-active": "@theme-common-hc-highlightText"
+        },
+        "#pressed": {
+          "icon-inactive": "@theme-common-hc-highlightText",
+          "favorite-icon-active": "@theme-common-hc-highlightText"
         }
       }
     }


### PR DESCRIPTION
Favourite icon requires different fill colour when selected in high contrast mode on windows.
Also borders were missing from interactive-icons in high contrast mode.

https://www.figma.com/file/rNpQFybgpgSfTmhLa441V3/Components---Windows-OS-HighContrast?node-id=18590%3A37844
