### PR TITLE
fix(win-hc): User correct hover background color for text input

### DIFF
--- a/platformcomponents/win-hc/text-input.json
+++ b/platformcomponents/win-hc/text-input.json
@@ -8,7 +8,8 @@
     "#hovered": {
       "text": "@theme-text-inverted-normal",
       "placeholder-text": "@theme-text-inverted-normal",
-      "background": "@theme-background-solid-primary-normal"
+      "background": "@theme-common-hc-highlight",
+      "border": "@theme-common-hc-highlight"
     },
     "#disabled": {
       "text": "@theme-text-primary-disabled",


### PR DESCRIPTION
Background was the same colour as text rendering it invisible.