### PR TITLE
feat(button-toggle-accent): add button toggle accent comp tokens

### DIFF
--- a/platformcomponents/desktop/toggle-button-accent.json
+++ b/platformcomponents/desktop/toggle-button-accent.json
@@ -1,0 +1,42 @@
+{
+  "toggleButton": {
+    "figma": "https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web?node-id=48160%3A80022",
+    "comment": "Applied to toggle buttons that use the accent color when active/selected",
+    "inactive": {
+      "#normal": {
+        "background": "@theme-button-secondary-normal",
+        "text": "@theme-text-secondary-normal"
+      },
+      "#hovered": {
+        "background": "@theme-button-secondary-hover",
+        "text": "@theme-text-primary-normal"
+      },
+      "#pressed": {
+        "background": "@theme-button-secondary-pressed",
+        "text": "@theme-text-primary-normal"
+      },
+      "#disabled": {
+        "background": "@theme-button-secondary-normal",
+        "text": "@theme-text-primary-disabled"
+      }
+    },
+    "active": {
+      "#normal": {
+        "background": "@theme-button-secondary-pressed",
+        "text": "@theme-text-accent-normal"
+      },
+      "#hovered": {
+        "background": "@theme-button-secondary-pressed",
+        "text": "@theme-text-accent-normal"
+      },
+      "#pressed": {
+        "background": "@theme-button-secondary-pressed",
+        "text": "@theme-text-accent-normal"
+      },
+      "#disabled": {
+        "background": "@theme-button-primary-disabled",
+        "text": "@theme-text-primary-disabled"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

When toggle buttons have an accent color on its selected state, they have a different set of colours accross their states (normal, hover, pressed, disabled). That is why a separate component for this has been created in this PR.

![image](https://user-images.githubusercontent.com/56999622/191762625-316269c0-6367-4a48-b69f-e2cbdb393111.png)

# Links

[*Links to relevent resources.*](https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=46549%3A102963)
