### PR TITLE
feat(toggle-button-accent-name): fix name

### DIFF
--- a/platformcomponents/desktop/toggle-button-accent.json
+++ b/platformcomponents/desktop/toggle-button-accent.json
@@ -1,5 +1,5 @@
 {
-  "toggleButton": {
+  "toggleButtonAccent": {
     "figma": "https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web?node-id=48160%3A80022",
     "comment": "Applied to toggle buttons that use the accent color when active/selected",
     "inactive": {


### PR DESCRIPTION
Name fix for ToggleButtonAccent component tokens. 
