### PR TITLE
feat(button-toggle-accent): update active tokens

### DIFF
--- a/platformcomponents/desktop/toggle-button-accent.json
+++ b/platformcomponents/desktop/toggle-button-accent.json
@@ -22,19 +22,19 @@
     },
     "active": {
       "#normal": {
-        "background": "@theme-button-secondary-pressed",
+        "background": "@theme-button-secondary-active-normal",
         "text": "@theme-text-accent-normal"
       },
       "#hovered": {
-        "background": "@theme-button-secondary-pressed",
+        "background": "@theme-button-secondary-active-hover",
         "text": "@theme-text-accent-normal"
       },
       "#pressed": {
-        "background": "@theme-button-secondary-pressed",
+        "background": "@theme-button-secondary-active-pressed",
         "text": "@theme-text-accent-normal"
       },
       "#disabled": {
-        "background": "@theme-button-primary-disabled",
+        "background": "@theme-button-secondary-active-normal",
         "text": "@theme-text-primary-disabled"
       }
     }


### PR DESCRIPTION
# Description
The Momentum Design team updated the active colours of the buttonToggleAccent.

Component in Figma
<img width="232" alt="image" src="https://user-images.githubusercontent.com/56999622/192262866-080de31f-82af-42d8-a2ce-bf07fe5fe977.png">

# Links
[*Links to relevent resources.*](https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web?node-id=49900%3A96263)
