### PR TITLE
feat(hc-message-header): change text warning color

### DIFF
--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -171,7 +171,7 @@
         "active": "@color-hc-PlaceholderColor"
       },
       "warning": {
-        "normal": "@color-hc-SystemColorWindowColor",
+        "normal": "@color-hc-SystemColorHighlightColor",
         "hover": "@color-hc-SystemColorHighlightTextColor",
         "active": "@color-hc-PlaceholderColor"
       },


### PR DESCRIPTION
Fix HC text warning color as specified here:
https://www.figma.com/file/rNpQFybgpgSfTmhLa441V3/Components---Windows-OS-HighContrast?node-id=20219%3A149636