### PR TITLE
color token for message header 

### DIFF
--- a/platformcomponents/desktop/messages.json
+++ b/platformcomponents/desktop/messages.json
@@ -57,18 +57,16 @@
             "text": "@theme-text-accent-normal"
           }
         }
+      }
+    },
+    "headerText": {
+      "default": {
+        "#normal": {
+          "text": "@theme-text-secondary-normal"
+        }
       },
       "extParticipants": {
         "#normal": {
-          "text": "@theme-text-warning-normal"
-        },
-        "#hovered": {
-          "text": "@theme-text-warning-hover"
-        },
-        "#active": {
-          "text": "@theme-text-warning-active"
-        },
-        "#focused": {
           "text": "@theme-text-warning-normal"
         }
       }

--- a/platformcomponents/desktop/messages.json
+++ b/platformcomponents/desktop/messages.json
@@ -57,6 +57,20 @@
             "text": "@theme-text-accent-normal"
           }
         }
+      },
+      "extParticipants": {
+        "#normal": {
+          "text": "@theme-text-warning-normal"
+        },
+        "#hovered": {
+          "text": "@theme-text-warning-hover"
+        },
+        "#active": {
+          "text": "@theme-text-warning-active"
+        },
+        "#focused": {
+          "text": "@theme-text-warning-normal"
+        }
       }
     },
     "headerText": {


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*
Needed a color token to be added specifically for the header of the message as we currently have of just the message body. 
* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description
Added two header tokens for the message header. One for the external domain and the other for the rest of the text. 
Took away the extParticipant from the message body as it was not being used
*The full description of the changes made in this request.*

# Links

*Links to relevent resources.*
