### PR TITLE
Add badge tokens for secondary and warning

### DIFF
--- a/components/badge.json
+++ b/components/badge.json
@@ -5,6 +5,11 @@
     "background": "@theme-background-accent-normal",
     "text": "@theme-common-text-white",
     "notification-indicator": "@theme-text-accent-normal",
-    "recording-indicator": "@theme-indicator-attention"
+    "recording-indicator": "@theme-indicator-attention",
+    "warning-indicator": "@theme-text-warning-normal",
+    "secondary": {
+      "background": "@theme-background-solid-secondary-normal",
+      "text": "@theme-text-secondary-normal"
+    }
   }
 }

--- a/components/badge.json
+++ b/components/badge.json
@@ -6,7 +6,8 @@
     "text": "@theme-common-text-white",
     "notification-indicator": "@theme-text-accent-normal",
     "recording-indicator": "@theme-indicator-attention",
-    "warning-indicator": "@theme-text-warning-normal",
+    "warning-indicator": "@theme-indicator-attention",
+    "warning-icon": "@theme-text-warning-normal",
     "secondary": {
       "background": "@theme-background-solid-secondary-normal",
       "text": "@theme-text-secondary-normal"


### PR DESCRIPTION
Tokens for new badge types added

https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=2925%3A17742&t=dwSXADFZEq3WbvJs-0
<img width="303" alt="Screenshot 2022-12-01 at 10 48 01" src="https://user-images.githubusercontent.com/87858909/205033668-16ba3777-5a77-4352-8357-19dc6b77134a.png">
