### PR TITLE
add hc hover color for message header on hover/focus states

### DIFF
--- a/platformcomponents/win-hc/messages.json
+++ b/platformcomponents/win-hc/messages.json
@@ -36,6 +36,17 @@
       "#focused": {
         "text": "@theme-text-inverted-normal"
       }
+    },
+    "headerText-default": {
+      "#pressed": {
+        "text": "@theme-text-inverted-normal"
+      },
+      "#hovered": {
+        "text": "@theme-text-inverted-normal"
+      },
+      "#focused": {
+        "text": "@theme-text-inverted-normal"
+      }
     }
   }
 }


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description
Add High Contrast colours for the message header texts on hover state and focused state
*The full description of the changes made in this request.*

# Links

*Links to relevent resources.*
