### PR TITLE
Adding partner colours (word, pdf, onenote, etc) for file content attachments

### DIFF
--- a/core/color/partners.json
+++ b/core/color/partners.json
@@ -1,0 +1,15 @@
+{
+  "color": {
+    "partner": {
+      "pdf": "#EE0507",
+      "word": "#0078D6",
+      "powerpoint": "#D93E17",
+      "excel": "#00893E",
+      "onenote": "#B839DB",
+      "doc": "#4285F4",
+      "sheets": "#F4B400",
+      "slides": "#0F9D58",
+      "keynotes": "#029CFB"
+    }
+  }
+}

--- a/platformcomponents/desktop/attachment-file-branded.json
+++ b/platformcomponents/desktop/attachment-file-branded.json
@@ -1,0 +1,31 @@
+{
+  "attachment-file-branded": {
+    "sent": {
+      "comment": "Applied to sent & safe branded file attachments",
+      "figma": "https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=5428%3A29",
+      "border": "@theme-outline-secondary-normal",
+      "previewBox": {
+        "icon": "@theme-common-text-white",
+        "background-pdf": "@theme-common-content-content-pdf",
+        "background-word": "@theme-common-content-content-word",
+        "background-powerpoint": "@theme-common-content-content-powerpoint",
+        "background-excel": "@theme-common-content-content-excel",
+        "background-onenote": "@theme-common-content-content-onenote",
+        "background-google-doc": "@theme-common-content-content-doc",
+        "background-google-sheets": "@theme-common-content-content-sheets",
+        "background-google-slides": "@theme-common-content-content-slides",
+        "background-keynote": "@theme-common-content-content-keynote"
+      },
+      "label": {
+        "primary": "@theme-text-primary-normal",
+        "secondary": "@theme-text-secondary-normal"
+      },
+      "background": {
+        "#normal": "@theme-background-secondary-normal",
+        "#hovered": "@theme-background-secondary-hover",
+        "#active": "@theme-background-secondary-active",
+        "#focused": "@theme-background-secondary-normal"
+      }
+    }
+  }
+}

--- a/platformcomponents/desktop/attachment-file-branded.json
+++ b/platformcomponents/desktop/attachment-file-branded.json
@@ -6,15 +6,17 @@
       "border": "@theme-outline-secondary-normal",
       "previewBox": {
         "icon": "@theme-common-text-white",
-        "background-pdf": "@theme-common-content-content-pdf",
-        "background-word": "@theme-common-content-content-word",
-        "background-powerpoint": "@theme-common-content-content-powerpoint",
-        "background-excel": "@theme-common-content-content-excel",
-        "background-onenote": "@theme-common-content-content-onenote",
-        "background-google-doc": "@theme-common-content-content-doc",
-        "background-google-sheets": "@theme-common-content-content-sheets",
-        "background-google-slides": "@theme-common-content-content-slides",
-        "background-keynote": "@theme-common-content-content-keynote"
+        "background" : {
+          "pdf": "@theme-common-content-pdf",
+          "word": "@theme-common-content-word",
+          "powerpoint": "@theme-common-content-powerpoint",
+          "excel": "@theme-common-content-excel",
+          "onenote": "@theme-common-content-onenote",
+          "doc": "@theme-common-content-doc",
+          "sheets": "@theme-common-content-sheets",
+          "slides": "@theme-common-content-slides",
+          "keynotes": "@theme-common-content-keynotes"
+        }
       },
       "label": {
         "primary": "@theme-text-primary-normal",

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -132,6 +132,17 @@
           "attention": "@color-red-40",
           "secure": "@color-blue-40"
         }
+      },
+      "content": {
+        "content-pdf": "@color-partner-pdf",
+        "content-word": "@color-partner-word",
+        "content-powerpoint": "@color-partner-powerpoint",
+        "content-excel": "@color-partner-excel",
+        "content-onenote": "@color-partner-onenote",
+        "content-doc": "@color-partner-doc",
+        "content-sheets": "@color-partner-sheets",
+        "content-slides": "@color-partner-slides",
+        "content-keynote": "@color-partner-keynotes"
       }
     }
   }

--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -134,15 +134,15 @@
         }
       },
       "content": {
-        "content-pdf": "@color-partner-pdf",
-        "content-word": "@color-partner-word",
-        "content-powerpoint": "@color-partner-powerpoint",
-        "content-excel": "@color-partner-excel",
-        "content-onenote": "@color-partner-onenote",
-        "content-doc": "@color-partner-doc",
-        "content-sheets": "@color-partner-sheets",
-        "content-slides": "@color-partner-slides",
-        "content-keynote": "@color-partner-keynotes"
+        "pdf": "@color-partner-pdf",
+        "word": "@color-partner-word",
+        "powerpoint": "@color-partner-powerpoint",
+        "excel": "@color-partner-excel",
+        "onenote": "@color-partner-onenote",
+        "doc": "@color-partner-doc",
+        "sheets": "@color-partner-sheets",
+        "slides": "@color-partner-slides",
+        "keynotes": "@color-partner-keynotes"
       }
     }
   }

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -143,6 +143,17 @@
           "attention": "@color-hc-PlaceholderColor",
           "secure": "@color-hc-PlaceholderColor"
         }
+      },
+      "content": {
+        "content-pdf": "@color-partner-pdf",
+        "content-word": "@color-partner-word",
+        "content-powerpoint": "@color-partner-powerpoint",
+        "content-excel": "@color-partner-excel",
+        "content-onenote": "@color-partner-onenote",
+        "content-doc": "@color-partner-doc",
+        "content-sheets": "@color-partner-sheets",
+        "content-slides": "@color-partner-slides",
+        "content-keynote": "@color-partner-keynotes"
       }
     },
     "text": {

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -145,15 +145,15 @@
         }
       },
       "content": {
-        "content-pdf": "@color-partner-pdf",
-        "content-word": "@color-partner-word",
-        "content-powerpoint": "@color-partner-powerpoint",
-        "content-excel": "@color-partner-excel",
-        "content-onenote": "@color-partner-onenote",
-        "content-doc": "@color-partner-doc",
-        "content-sheets": "@color-partner-sheets",
-        "content-slides": "@color-partner-slides",
-        "content-keynote": "@color-partner-keynotes"
+        "pdf": "@color-hc-SystemColorHighlightColor",
+        "word": "@color-hc-SystemColorHighlightColor",
+        "powerpoint": "@color-hc-SystemColorHighlightColor",
+        "excel": "@color-hc-SystemColorHighlightColor",
+        "onenote": "@color-hc-SystemColorHighlightColor",
+        "doc": "@color-hc-SystemColorHighlightColor",
+        "sheets": "@color-hc-SystemColorHighlightColor",
+        "slides": "@color-hc-SystemColorHighlightColor",
+        "keynotes": "@color-hc-SystemColorHighlightColor"
       }
     },
     "text": {


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

Adding new tokens to support "partner" colours for file bricklet attachments (word, excel, PDF, etc).

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description


https://www.figma.com/file/n9T5usku57ecvPArT9SpWO/Tokens---Core-Color?node-id=3906%3A2&t=ZYuvVMkkHBjPHmSI-0
https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?node-id=2547%3A0&t=oJe9sbjQooTxKrJG-0

<img width="581" alt="Screenshot 2023-01-11 at 15 03 15" src="https://user-images.githubusercontent.com/44676517/211840360-5afe1378-3830-4ce8-9237-3573dc92197d.png">
<img width="459" alt="Screenshot 2023-01-11 at 15 04 35" src="https://user-images.githubusercontent.com/44676517/211840648-f837619f-7379-4d35-b0df-a61ffaf1a91d.png">



# Links

*Links to relevent resources.*
