### PR TITLE
 SPARK-378340 adapts IMC for "Always dark theme"

### DIFF
--- a/platformcomponents/desktop/messages.json
+++ b/platformcomponents/desktop/messages.json
@@ -73,6 +73,12 @@
         }
       }
     },
+    "listItem": {
+      "#normal":  "@theme-background-solid-primary-normal",
+      "#hovered": "@theme-background-solid-tertiary-normal",
+      "#pressed": "@theme-background-highlight-normal",
+      "#checked":  "@theme-background-highlight-checked"
+    },
     "headerText": {
       "default": {
         "#normal": {

--- a/theme-data/dark/dark-common.json
+++ b/theme-data/dark/dark-common.json
@@ -62,6 +62,10 @@
         "active": "@color-white-alpha-11",
         "disabled": "@color-white-alpha-11"
       },
+      "highlight": {
+        "normal": "@color-blue-90",
+        "checked": "@color-blue-80"
+      },
       "solid": {
         "primary": {
           "normal": "@color-black-alpha-100"

--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -62,6 +62,10 @@
         "active": "@color-black-alpha-11",
         "disabled": "@color-black-alpha-11"
       },
+      "highlight": {
+        "normal": "@color-blue-10",
+        "checked": "@color-blue-05"
+      },
       "solid": {
         "primary": {
           "normal": "@color-white-alpha-100"


### PR DESCRIPTION
# Description

SPARK-378340 adapts IMC for "Always dark theme", current message bubble selection color is blue-05(light) and blue-80(dark), they don't exist in current token list, so add them

