### PR TITLE
Add indicator-caution color

### DIFF
--- a/components/badge.json
+++ b/components/badge.json
@@ -7,6 +7,7 @@
     "notification-indicator": "@theme-text-accent-normal",
     "recording-indicator": "@theme-indicator-attention",
     "warning-indicator": "@theme-indicator-unstable",
+    "caution-indicator": "@theme-indicator-caution",
     "warning-icon": "@theme-text-warning-normal",
     "success-indicator": "@theme-text-success-normal",
     "error-indicator": "@theme-text-error-normal",


### PR DESCRIPTION
# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*
UX need to add the Indicator-caution
https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861-6638&t=2WfGU7Dj2UkbSNCv-0
```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/tokens/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/tokens/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/tokens/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*

# Links

*Links to relevent resources.*
