### PR TITLE
feat(update-tokens): update theme tokens with latest Figma

### DIFF
--- a/theme-data/common/common.json
+++ b/theme-data/common/common.json
@@ -37,7 +37,7 @@
         },
         "secondary": {
           "normal": "@color-white-alpha-00",
-          "hover": "@color-white-alpha-07",          
+          "hover": "@color-white-alpha-07",
           "disabled": "@color-white-alpha-00",
           "active": {
             "normal": "@color-white-alpha-20",
@@ -89,6 +89,9 @@
         "solid": {
           "secondary-dark": "@color-gray-95",
           "primary-light": "@color-white-alpha-100"
+        },
+        "alert-share": {
+          "normal": "@color-orange-60"
         }
       },
       "touchbar": {

--- a/theme-data/dark/dark-common.json
+++ b/theme-data/dark/dark-common.json
@@ -125,6 +125,9 @@
           "hover": "@color-orange-90",
           "active": "@color-orange-80"
         }
+      },
+      "reaction": {
+        "normal": ["@color-gray-95*0.9", "@color-gray-50*0"]
       }
     },
     "button": {
@@ -208,6 +211,9 @@
       },
       "high-contrast": {
         "focus": "@color-white-alpha-100"
+      },
+      "warning": {
+        "normal": "@color-yellow-40"
       }
     },
     "control": {
@@ -216,18 +222,21 @@
         "hover": "@theme-color-50",
         "pressed": "@theme-color-60",
         "active": "@theme-color-60",
-        "disabled": "@theme-color-80"
+        "disabled": "@color-white-alpha-20"
       },
       "inactive": {
         "normal": "@color-white-alpha-20",
         "hover": "@color-white-alpha-30",
         "pressed": "@color-white-alpha-40",
-        "disabled": "@color-white-alpha-11"
+        "disabled": "@color-white-alpha-20"
       }
     },
     "overlay": {
       "meetings": {
-        "normal": "@color-black-alpha-70"
+        "normal": "@color-black-alpha-70",
+        "reaction": {
+          "normal": ["@color-black-alpha-100*0.9", "@color-black-alpha-100*0"]
+        }
       }
     },
     "indicator": {

--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -125,6 +125,9 @@
           "hover": "@color-orange-10",
           "active": "@color-orange-20"
         }
+      },
+      "reaction": {
+        "normal": ["@color-white-alpha-100*0.9", "@color-white-alpha-100*0"]
       }
     },
     "button": {
@@ -208,6 +211,9 @@
       },
       "high-contrast": {
         "focus": "@color-black-alpha-100"
+      },
+      "warning": {
+        "normal": "@color-yellow-60"
       }
     },
     "control": {
@@ -216,18 +222,21 @@
         "hover": "@theme-color-70",
         "pressed": "@theme-color-80",
         "active": "@theme-color-80",
-        "disabled": "@theme-color-20"
+        "disabled": "@color-black-alpha-20"
       },
       "inactive": {
         "normal": "@color-black-alpha-20",
         "hover": "@color-black-alpha-30",
         "pressed": "@color-black-alpha-40",
-        "disabled": "@color-black-alpha-11"
+        "disabled": "@color-black-alpha-20"
       }
     },
     "overlay": {
       "meetings": {
-        "normal": "@color-white-alpha-80"
+        "normal": "@color-white-alpha-80",
+        "reaction": {
+          "normal": ["@color-gray-05*0.9", "@color-gray-05*0"]
+        }
       }
     },
     "indicator": {

--- a/theme-data/win-system-hc/win-system-hc-common.json
+++ b/theme-data/win-system-hc/win-system-hc-common.json
@@ -100,6 +100,9 @@
         "solid": {
           "secondary-dark": "@color-hc-SystemColorWindowTextColor",
           "primary-light": "@color-hc-SystemColorWindowTextColor"
+        },
+        "alert-share": {
+          "normal": "@color-hc-PlaceholderColor"
         }
       },
       "touchbar": {
@@ -334,6 +337,9 @@
           "active": "@color-hc-SystemColorHighlightColor"
         }
       },
+      "reaction": {
+        "normal": ["@color-hc-PlaceholderColor", "@color-hc-PlaceholderColor"]
+      },
       "label": {
         "cobalt": {
           "normal": "@color-hc-SystemColorButtonFaceColor",
@@ -390,7 +396,10 @@
     },
     "overlay": {
       "meetings": {
-        "normal": "@color-hc-PlaceholderColor"
+        "normal": "@color-hc-PlaceholderColor",
+        "reaction": {
+          "normal": ["@color-hc-PlaceholderColor", "@color-hc-PlaceholderColor"]
+        }
       }
     },
     "button": {
@@ -475,6 +484,9 @@
       },
       "high-contrast": {
         "focus": "@color-hc-SystemColorHighlightColor"
+      },
+      "warning": {
+        "normal": "@color-hc-SystemColorHighlightColor"
       },
       "label": {
         "cobalt": "@color-hc-SystemColorHighlightColor",


### PR DESCRIPTION
# Description

Updating some theme tokens with latest value according to Figma
https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861-6638&t=6rWdTSCboEVpeu1a-0

CHANGES MADE:
Common
• [Common-BackgroundAlertShare-normal](https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=3078%3A6338&t=1E4LU4xGkXIcrQwL-1)

Dark / Light both (Links direct to dark)
• [BackgroundReaction-normal](https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861%3A6638&t=1E4LU4xGkXIcrQwL-1)
• [OverlayMeetingsReaction-normal](https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861%3A6638&t=1E4LU4xGkXIcrQwL-1)
• [OutlineWarning-normal](https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861%3A6638&t=1E4LU4xGkXIcrQwL-1)

And lastly, there are HEX values changed.

• [ControlActive-disabled](https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861%3A6638&t=1E4LU4xGkXIcrQwL-1)
- Dark: theme-80 -> white-alpha-20
- Light:  theme-20-> black-alpha-20
•[ControlInactive-disabled](https://www.figma.com/file/yYfvFEEr3UkW1yUKkW7zEH/Tokens---Theme-Color?node-id=861%3A6638&t=1E4LU4xGkXIcrQwL-1)
- Dark:  white-alpha-11 -> white-alpha-20
- Light:  black-alpha-11-> black-alpha-20
