### PR TITLE
Add token for message overlay background

### DIFF
--- a/platformcomponents/desktop/messages.json
+++ b/platformcomponents/desktop/messages.json
@@ -91,13 +91,11 @@
         }
       }
     },
-    "overlay": {
-      "background": {
-        "#normal": "@theme-background-primary-ghost",
-        "#hovered": "@theme-background-primary-hover",
-        "#pressed": "@theme-background-primary-active",
-        "#active": "@theme-background-primary-active"
-      }
+    "background": {
+      "#normal": "@theme-background-primary-ghost",
+      "#hovered": "@theme-background-primary-hover",
+      "#pressed": "@theme-background-primary-active",
+      "#active": "@theme-background-primary-active"
     }
   }
 }

--- a/platformcomponents/desktop/messages.json
+++ b/platformcomponents/desktop/messages.json
@@ -94,8 +94,7 @@
     "background": {
       "#normal": "@theme-background-primary-ghost",
       "#hovered": "@theme-background-primary-hover",
-      "#pressed": "@theme-background-primary-active",
-      "#active": "@theme-background-primary-active"
+      "#pressed": "@theme-background-primary-active"
     }
   }
 }

--- a/platformcomponents/desktop/messages.json
+++ b/platformcomponents/desktop/messages.json
@@ -90,6 +90,14 @@
           "text": "@theme-text-warning-hover"
         }
       }
+    },
+    "overlay": {
+      "background": {
+        "#normal": "@theme-background-primary-ghost",
+        "#hovered": "@theme-background-primary-hover",
+        "#pressed": "@theme-background-primary-active",
+        "#active": "@theme-background-primary-active"
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

Adds token for message overlay background colours.

# Links

https://www.figma.com/file/H19CutixoN8SJGO5EXwcc8/Components---MacOS?type=design&node-id=3597%3A582&t=zEnIRgn4AIfBQRgM-1
