### PR TITLE
feat(theme-data): Sync the scroll button colors

### DIFF
--- a/theme-data/dark/dark-common.json
+++ b/theme-data/dark/dark-common.json
@@ -258,9 +258,9 @@
     },
     "scrollbar": {
       "button": {
-        "normal": "@color-white-alpha-20",
-        "hover": "@color-white-alpha-30",
-        "pressed": "@color-white-alpha-40"
+        "normal": "@color-white-alpha-40",
+        "hover": "@color-white-alpha-50",
+        "pressed": "@color-white-alpha-60"
       },
       "arrow": {
         "normal": "@color-white-alpha-70",

--- a/theme-data/light/light-common.json
+++ b/theme-data/light/light-common.json
@@ -258,9 +258,9 @@
     },
     "scrollbar": {
       "button": {
-        "normal": "@color-black-alpha-20",
-        "hover": "@color-black-alpha-30",
-        "pressed": "@color-black-alpha-40"
+        "normal": "@color-black-alpha-40",
+        "hover": "@color-black-alpha-50",
+        "pressed": "@color-black-alpha-60"
       },
       "arrow": {
         "normal": "@color-black-alpha-60",


### PR DESCRIPTION
#### The PR is for sync the design library and token for scroll bar button

- The library has updated the token values for the scroll bar button here: https://www.figma.com/design/NaNrfXjygZtRgMfHAFHjsp/%F0%9F%A7%A9-Webex-App---Windows?node-id=6851-1&m=dev

- But the token is not synced: https://github.com/momentum-design/tokens/blob/master/theme-data/dark/dark-common.json#L261C12-L261C43




<img width="1188" alt="en-US 16" src="https://github.com/momentum-design/tokens/assets/2640513/28afc1e3-661f-4820-afff-760f340591bb">
